### PR TITLE
fix: Change link syntax to be markdown

### DIFF
--- a/content/programs/grants/Pose.md
+++ b/content/programs/grants/Pose.md
@@ -1,6 +1,6 @@
 ---
 title: "OMSF POSE"
-image: 
+image:
 part: 10
 category: "ecosystem"
 intro: "Aimed at growing and supporting our ecosystem as a distributed network of autonomous communities connected via shared infrastructure, processes, and values, the Ecosystem Infrastructure team at OMSF is sponsored by the NSF through the POSE grant."
@@ -9,7 +9,7 @@ more: true
 
 The NSF POSE Phase II project, awarded to OMSF in September 2023, focuses on enhancing the open-source ecosystem in molecular sciences through strategic collaboration and technological innovation. It aims to leverage the expertise of OMSF’s in-house software engineers to build a shared infrastructure across OMSF’s hosted projects. These contributions are expected to advance the development of programs and foster a collaborative environment for scientific software development, aligning with the project's goals to bolster molecular modeling and open science practices.
 
-For more details about the goals of this project, visit this <Zenodo page>(https://zenodo.org/records/8388247?ref=news.omsf.io). For the latest updates regarding this initiative, visit <https://news.omsf.io>.
+For more details about the goals of this project, visit this [Zenodo page](https://zenodo.org/records/8388247?ref=news.omsf.io). For the latest updates regarding this initiative, visit [https://news.omsf.io](https://news.omsf.io).
 
-**Github**: <https://github.com/omsf>  
+**Github**: [https://github.com/omsf](https://github.com/omsf)
 **Contact**: Karmen Condic-Jurkic


### PR DESCRIPTION
This change fixes the link syntax to be proper markdown links.