### PR TITLE
Fix missing mailto links

### DIFF
--- a/content/involved/bringproject.md
+++ b/content/involved/bringproject.md
@@ -20,4 +20,4 @@ We also host events and gatherings that foster and educate communities about the
   
 OMSF ensures that hosted projects receive the administrative support needed to focus on scientific and technical advancements rather than operational overhead. If interested, read about [What We Do](https://omsf.io/resources/fiscalsponsorship/). And if you are looking for examples of the kinds of projects OMSF hosts, head over to our [Projects](https://omsf.io/programs/projects/) page.
 
-If you need it, we are happy to work with you in structuring your proposal. If interested in hosting your project at OMSF, reach us at [info@omsf.io](info@omsfio)
+If you need it, we are happy to work with you in structuring your proposal. If interested in hosting your project at OMSF, reach us at [info@omsf.io](mailto:info@omsfio)

--- a/content/involved/contributor.md
+++ b/content/involved/contributor.md
@@ -13,4 +13,4 @@ OMSF is always looking for new academic collaborators. We engage with the academ
  - **Joint Grant Initiatives**: We collaborate regualry with researchers on funding proposals, supporting applications for grants from government agencies, philanthropic foundations, and industry consortiums to advance shared research goals.
  - **Expert Contracting**: We connect domain experts from within our community with funded projects, ensuring that cutting-edge research receives the expertise and development support necessary to make an impact.  
 
-If you're excited to contribute but not sure where to start, we want to hear from you. Reach out to [info@omsf.io](info@omsf.io).
+If you're excited to contribute but not sure where to start, we want to hear from you. Reach out to [info@omsf.io](mailto:info@omsf.io).

--- a/content/resources/fiscalsponsorship.md
+++ b/content/resources/fiscalsponsorship.md
@@ -19,7 +19,7 @@ OMSF achieves efficiencies in administration and funding, reducing the burden on
 
 OMSF also provides support to those wishing to promote their own molecular science communities. Whether it be organizing events, educating, or showing the best in class, OMSF provides a proven method for in-person and remote organizations to host webinars, in-person meetings, or community gatherings.
 
-If you are interested in bringing your project to OMSF, [email us here!](info@omsf.io).
+If you are interested in bringing your project to OMSF, [email us here!](mailto:info@omsf.io).
 
 We offer the following services to Hosted Projects:
 


### PR DESCRIPTION
## Description

I found several bad links for the info email address. These are treated as relative links on the live site, instead of mailto links. This fixes it.

## Changes Made

Fix links on:

* https://omsf.io/involved/contributor/
* https://omsf.io/involved/bringproject/
* https://omsf.io/resources/fiscalsponsorship/

## Type of Change
<!-- Mark relevant items with an [x] -->
- [ ] Content Update
- [ ] New Content Addition
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Other (please describe):

## Areas Affected
* https://omsf.io/involved/contributor/
* https://omsf.io/involved/bringproject/
* https://omsf.io/resources/fiscalsponsorship/

## Verification
<!-- Mark completed items with an [x] -->
- [ ] Content is accurate and up-to-date
- [ ] Changes follow existing formatting patterns
- [x] Links have been tested (if applicable)
- [ ] No sensitive information included
- [ ] Changes have been previewed locally

## Additional Notes
<!-- Add any other context about the changes here -->

## Reviewer Notes
<!-- Any specific points you want reviewers to focus on -->

/cc @zachary-baker
