### PR TITLE
feat: add "Software Directory" menu item in config.toml

### DIFF
--- a/themes/hugo-kiera-master/config.toml
+++ b/themes/hugo-kiera-master/config.toml
@@ -97,6 +97,12 @@ section = ["HTML", "RSS", "JSON"]
             url = "https://playbooks.omsf.io"
             parent = "community"
             weight = 50
+          [[menu.main]]
+            identifier = "directory"
+            name = "Software Directory"
+            url = "https://directory.omsf.io"
+            parent = "community"
+            weight = 60
 
         [[menu.main]]
         identifier = "involved"


### PR DESCRIPTION
## Description
Add a new entry for the Software Directory in the main menu with identifier "directory", linking to https://directory.omsf.io and positioning it under the "community" parent with a weight of 60. This enhances the navigation options and centralizes access to the software directory.
<!-- Provide a brief overview of your changes -->

## Changes Made
<!-- List the specific changes you've made -->
Adds new OMSF directory

## Type of Change
<!-- Mark relevant items with an [x] -->
- [ ] Content Update
- [x] New Content Addition
- [ ] Bug Fix
- [ ] Documentation Update
- [ ] Other (please describe):

## Areas Affected
<!-- List which sections/pages are impacted -->
Main page

## Verification
<!-- Mark completed items with an [x] -->
- [x] Content is accurate and up-to-date
- [x] Changes follow existing formatting patterns
- [x] Links have been tested (if applicable)
- [x] No sensitive information included
- [x] Changes have been previewed locally

## Additional Notes
<!-- Add any other context about the changes here -->

## Reviewer Notes
<!-- Any specific points you want reviewers to focus on -->

/cc @zacharbake @ethanholz
