### PR TITLE
Fix markdown for link to Apache code of conduct

### DIFF
--- a/content/resources/conduct.md
+++ b/content/resources/conduct.md
@@ -4,7 +4,7 @@ name: "conduct"
 weight: 1
 ---
 
-This Code of Conduct is based on the (Apache Foundation Code of Conduct)[https://www.apache.org/foundation/policies/conduct.html] and modified accordingly.
+This Code of Conduct is based on the [Apache Foundation Code of Conduct](https://www.apache.org/foundation/policies/conduct.html) and modified accordingly.
 
 Last modified: June 2, 2022.
 


### PR DESCRIPTION
## Description
Fix incorrect markdown syntax for link to Apache Code of Conduct
## Changes Made
Fix incorrect markdown syntax for link to Apache Code of Conduct

## Type of Change
<!-- Mark relevant items with an [x] -->
- [ ] Content Update
- [ ] New Content Addition
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Other (please describe):

## Areas Affected
<!-- List which sections/pages are impacted -->
Code of conduct

## Verification
<!-- Mark completed items with an [x] -->
- [x] Content is accurate and up-to-date
- [x] Changes follow existing formatting patterns
- [x] Links have been tested (if applicable)
- [x] No sensitive information included
- [x] Changes have been previewed locally

## Additional Notes
<!-- Add any other context about the changes here -->
As far as I can tell, the code of conduct is not reachable by any links on the site. Is this intentional? I found this bug because the project playbook links to it. When trying to preview locally, I couldn't find a way to navigate to the code of conduct from the main site.

## Reviewer Notes
<!-- Any specific points you want reviewers to focus on -->

/cc @zacharbake @ethanholz
