### PR TITLE
Menus: Use small downward triangle instead of medium

### DIFF
--- a/themes/hugo-kiera-master/static/css/agathe.css
+++ b/themes/hugo-kiera-master/static/css/agathe.css
@@ -211,7 +211,7 @@ li.menu-item-has-children:not(.mobile-submenu li) {
   display: inline-block;
 }
 li.menu-item-has-children a.menu-link::after{
-  content: "\0023F7";
+  content: "\0025be";
   padding-left: 15px;
   color: var(--color-une-dark);
 }


### PR DESCRIPTION
## Description
Menus on the site have a triangle next to them to indicate that they have content. The previous CSS used "black medium down-pointing triangle." However, apparently there's a problem displaying that on Linux. This PR replaces it with "black small down-pointing triangle."

Alternate solutions:

* Replace with "black down-pointing triangle": tried, I thought it looked ugly.
* Figure out exactly why that character doesn't get loaded in the font set on Linux: This seemed like a LOT more work than just changing 4 characters in CSS, for little advantage.

Fixes #45 (once we get confirmation of that).

## Changes Made
Change the symbol used in CSS.

## Type of Change
<!-- Mark relevant items with an [x] -->
- [ ] Content Update
- [ ] New Content Addition
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Other (please describe):

## Areas Affected
All pages with menus across the top

## Verification
- [x] Content is accurate and up-to-date
- [x] Changes follow existing formatting patterns
- [x] Links have been tested (if applicable)
- [x] No sensitive information included
- [x] Changes have been previewed locally

## Additional Notes
<!-- Add any other context about the changes here -->

## Reviewer Notes
<!-- Any specific points you want reviewers to focus on -->

/cc @zacharbake @ethanholz
