### PR TITLE
feat: redirect current events to events site

### DIFF
--- a/content/community/events/past-events.md
+++ b/content/community/events/past-events.md
@@ -9,6 +9,43 @@ part: 20
 
 ![Events](/images/event.svg)
 
+## Barcelona 2026
+
+In May 2026, OMSF and our partners will gather in Barcelona for a week of coordinated events, bringing together one of the largest annual gatherings of computational chemists. Consisting of three connected events, the week is scheduled sequentially to allow participants to attend multiple programs during a single visit to Barcelona.
+
+### The Free Energy Workshop 2026
+
+Hosted by the Alchemistry project, this long-standing workshop will focus on free energy methods in drug design, attracting researchers and practitioners to discuss methodology and real-world applications.
+
+**When**: May 4-6, 2026  
+**Schedule**: [https://omsf.io/alchemistry/program/schedule/](https://omsf.io/alchemistry/program/schedule/)  
+**Registration**: [$267](https://www.zeffy.com/en-US/ticketing/register-for-the-2026-free-energy-workshop)  
+Interested in presenting? Submit your abstract [here](https://forms.gle/FngCh66Z9BvxqMCZ8).  
+
+### CoFold Summit
+
+The inaugural CoFold Summit brings together researchers and developers working on structure prediction, with programming focused on technical exchange and cross-project discussion. 
+
+**When**: May 6, 2026  
+**Schedule**: [https://omsf.notion.site/cofold-summit-speakerlist](https://omsf.notion.site/cofold-summit-speakerlist)  
+**Registration**: [https://luma.com/yklxc0ib (Sold Out)](https://luma.com/yklxc0ib)  
+
+### OMSF Symposium 2026
+
+The OMSF Symposium serves as the anchor gathering for the community, bringing together contributors, academics, and industry partners to share recent developments across our software projects and explore the future of molecular software together.
+
+**When**: May 7-8, 2026  
+**Schedule**: [https://omsf.notion.site/omsf-symposium-2026-speakerlist](https://omsf.notion.site/omsf-symposium-2026-speakerlist)  
+**Registration**: [https://luma.com/of677kui (Sold Out)](https://luma.com/of677kui)  
+
+
+## Boston Open Science & Innovation Forum
+
+The Boston Open Science & Innovation Forum is a community gathering celebrating Boston’s open science ecosystem. The event focuses on connecting individuals working in open science to break down traditional silos in biotech and drug discovery through open collaboration.
+
+When: March 18, 2026  
+Information and Registration: [$0](https://luma.com/o5disge6)  
+
 ### OMSF Symposium 2025
 
 In May of 2025, OMSF gathered at the Museum of Science in Boston, MA for our third annual symposium!

--- a/content/community/events/upcoming-events.md
+++ b/content/community/events/upcoming-events.md
@@ -5,42 +5,8 @@ name: "Upcoming Events"
 class: "events future"
 intro: "OMSF has regular events scheduled every year. Learn more here."
 part: 20
+redirect_to: "https://events.omsf.io"
 ---
 
-## Barcelona 2026
-
-In May 2026, OMSF and our partners will gather in Barcelona for a week of coordinated events, bringing together one of the largest annual gatherings of computational chemists. Consisting of three connected events, the week is scheduled sequentially to allow participants to attend multiple programs during a single visit to Barcelona.
-
-### The Free Energy Workshop 2026
-
-Hosted by the Alchemistry project, this long-standing workshop will focus on free energy methods in drug design, attracting researchers and practitioners to discuss methodology and real-world applications.
-
-**When**: May 4-6, 2026  
-**Schedule**: [https://omsf.io/alchemistry/program/schedule/](https://omsf.io/alchemistry/program/schedule/)  
-**Registration**: [$267](https://www.zeffy.com/en-US/ticketing/register-for-the-2026-free-energy-workshop)  
-Interested in presenting? Submit your abstract [here](https://forms.gle/FngCh66Z9BvxqMCZ8).  
-
-### CoFold Summit
-
-The inaugural CoFold Summit brings together researchers and developers working on structure prediction, with programming focused on technical exchange and cross-project discussion. 
-
-**When**: May 6, 2026  
-**Schedule**: [https://omsf.notion.site/cofold-summit-speakerlist](https://omsf.notion.site/cofold-summit-speakerlist)  
-**Registration**: [https://luma.com/yklxc0ib (Sold Out)](https://luma.com/yklxc0ib)  
-
-### OMSF Symposium 2026
-
-The OMSF Symposium serves as the anchor gathering for the community, bringing together contributors, academics, and industry partners to share recent developments across our software projects and explore the future of molecular software together.
-
-**When**: May 7-8, 2026  
-**Schedule**: [https://omsf.notion.site/omsf-symposium-2026-speakerlist](https://omsf.notion.site/omsf-symposium-2026-speakerlist)  
-**Registration**: [https://luma.com/of677kui (Sold Out)](https://luma.com/of677kui)  
-
-
-## Boston Open Science & Innovation Forum
-
-The Boston Open Science & Innovation Forum is a community gathering celebrating Boston’s open science ecosystem. The event focuses on connecting individuals working in open science to break down traditional silos in biotech and drug discovery through open collaboration.
-
-When: March 18, 2026  
-Information and Registration: [$0](https://luma.com/o5disge6)  
+You are being redirected to [https://events.omsf.io](https://events.omsf.io).
 

--- a/themes/hugo-kiera-master/layouts/_default/baseof.html
+++ b/themes/hugo-kiera-master/layouts/_default/baseof.html
@@ -5,10 +5,17 @@
     <head>
         <title>OMSF — {{ .Page.Title }}</title>
         {{ partial "meta" . }}
+        {{ with .Params.redirect_to }}
+        <meta http-equiv="refresh" content="0; url={{ . }}" />
+        <link rel="canonical" href="{{ . }}" />
+        {{ end }}
         {{ partialCached "header_includes" . -}}
     </head>
 
     <body class="{{block "bodyClass" .}} {{ end }} {{ if .Params.class }} {{ .Params.class }} {{ end }} {{ .Page.Section }}">
+        {{ with .Params.redirect_to }}
+        <script>window.location.replace("{{ . }}");</script>
+        {{ end }}
 
         <div id="container">
 

--- a/themes/hugo-kiera-master/layouts/_default/baseof.html
+++ b/themes/hugo-kiera-master/layouts/_default/baseof.html
@@ -6,15 +6,21 @@
         <title>OMSF — {{ .Page.Title }}</title>
         {{ partial "meta" . }}
         {{ with .Params.redirect_to }}
+        {{ $u := urls.Parse . }}
+        {{ if or (eq $u.Scheme "") (in (slice "http" "https") $u.Scheme) }}
         <meta http-equiv="refresh" content="0; url={{ . }}" />
         <link rel="canonical" href="{{ . }}" />
+        {{ end }}
         {{ end }}
         {{ partialCached "header_includes" . -}}
     </head>
 
     <body class="{{block "bodyClass" .}} {{ end }} {{ if .Params.class }} {{ .Params.class }} {{ end }} {{ .Page.Section }}">
         {{ with .Params.redirect_to }}
-        <script>window.location.replace("{{ . }}");</script>
+        {{ $u := urls.Parse . }}
+        {{ if or (eq $u.Scheme "") (in (slice "http" "https") $u.Scheme) }}
+        <script>window.location.replace({{ . | jsonify }});</script>
+        {{ end }}
         {{ end }}
 
         <div id="container">

--- a/themes/hugo-kiera-master/layouts/_default/baseof.html
+++ b/themes/hugo-kiera-master/layouts/_default/baseof.html
@@ -6,21 +6,15 @@
         <title>OMSF — {{ .Page.Title }}</title>
         {{ partial "meta" . }}
         {{ with .Params.redirect_to }}
-        {{ $u := urls.Parse . }}
-        {{ if or (eq $u.Scheme "") (in (slice "http" "https") $u.Scheme) }}
         <meta http-equiv="refresh" content="0; url={{ . }}" />
         <link rel="canonical" href="{{ . }}" />
-        {{ end }}
         {{ end }}
         {{ partialCached "header_includes" . -}}
     </head>
 
     <body class="{{block "bodyClass" .}} {{ end }} {{ if .Params.class }} {{ .Params.class }} {{ end }} {{ .Page.Section }}">
         {{ with .Params.redirect_to }}
-        {{ $u := urls.Parse . }}
-        {{ if or (eq $u.Scheme "") (in (slice "http" "https") $u.Scheme) }}
-        <script>window.location.replace({{ . | jsonify }});</script>
-        {{ end }}
+        <script>window.location.replace("{{ . }}");</script>
         {{ end }}
 
         <div id="container">


### PR DESCRIPTION
Move the current events copy into past events and make the current events page redirect to the dedicated events site.

Assisted-by: Pi:openai-codex/gpt-5.5
