### PR TITLE
Fix typo in code of conduct

### DIFF
--- a/content/resources/conduct.md
+++ b/content/resources/conduct.md
@@ -56,7 +56,7 @@ The Code of Conduct, above, details our standards for behaviour in the OMSF comm
 #### REPORTING GUIDELINES
 
 While all participants should adhere to this code of conduct, we recognize that sometimes people may have a bad day, or be unaware of some of the code's guidelines. When that happens, you may reply to them and point out this code of conduct. Such messages may be in public or in private, whatever is most appropriate. However, regardless of whether the message is public or not, it should still adhere to the relevant parts of this code of conduct; in particular, it should not be abusive or disrespectful.
-Assume good faith; it is more likely that participants are unaware of their bad behaviour than that they intentionally try to degrade the quality of the discussion. Should there be difficulties in dealing with the situation, you may report your compliance issues in confidence to board at omsf.io or director @ omsf.io
+Assume good faith; it is more likely that participants are unaware of their bad behaviour than that they intentionally try to degrade the quality of the discussion. Should there be difficulties in dealing with the situation, you may report your compliance issues in confidence to board@omsf.io or director@omsf.io
 If the violation is in documentation or code, for example inappropriate pronoun usage or word choice within official documentation, report these privately to the project in question at their contact email addresses, and, if you have sufficient ability within the project, resolve or remove the concerning material, being mindful of the perspective of the person originally reporting the issue.
 
 #### NOTES


### PR DESCRIPTION
## Description
I was reviewing the code of conduct and noticed that the contact emails were listed inconsistently. This aims to fix them and make them both valid email addresses. 

## Changes Made
Changed formatting of contact emails in code of conduct. 

## Type of Change
<!-- Mark relevant items with an [x] -->
- [x] Content Update
- [ ] New Content Addition
- [ ] Bug Fix
- [ ] Documentation Update
- [ ] Other (please describe):

## Areas Affected
Code of conduct

## Verification
<!-- Mark completed items with an [x] -->
- [x] Content is accurate and up-to-date
- [x] Changes follow existing formatting patterns
- [ ] ~Links have been tested (if applicable)~
- [ ] No sensitive information included
  - I don't know if y'all would consider full-text valid emails sensitive (maybe that was the reason for the original formatting)
- [ ] Changes have been previewed locally

## Additional Notes

I'm not particular about the final format of the email addresses in the code of conduct, this is just a drive-by PR and it's fine by me if this is closed and resolved some other way.
